### PR TITLE
Mainchain - add network overview page

### DIFF
--- a/src/.vuepress/components/Network/Overview.vue
+++ b/src/.vuepress/components/Network/Overview.vue
@@ -1,0 +1,40 @@
+<template>
+  <div>
+    <h3>Upgrades</h3>
+    <Network-Upgrades :upgrades="networkInfo.upgrades" />
+    <h3>Nodes & Services</h3>
+    <Network-Services
+        :services="networkInfo.services"
+        :currentChainId="networkInfo.current_chain_id"
+        :numCommunity="numCommunity"
+        :numLegacy="numLegacy"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    network: { required: true, type: String },
+  },
+  data() {
+    return {
+      networkInfo: {
+        upgrades: [],
+        services: {},
+      },
+      numCommunity: 0,
+      numLegacy: 0,
+    };
+  },
+  mounted() {
+    fetch(`https://raw.githubusercontent.com/unification-com/${this.network}/master/latest/network_info.json`, {cache: "no-cache"})
+        .then(response => response.json())
+        .then(data => {
+          this.networkInfo = data
+          this.numCommunity = data.services.seed.community.length + data.services.rpc.community.length + data.services.rest.community.length + data.services.explorer.community.length
+          this.numLegacy = data.services.seed.legacy.length + data.services.rpc.legacy.length + data.services.rest.legacy.length + data.services.explorer.legacy.length
+        });
+  }
+}
+</script>

--- a/src/.vuepress/components/Network/ServiceItem.vue
+++ b/src/.vuepress/components/Network/ServiceItem.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    {{ item.name }}<br />
+    <span v-if="item.link">
+      <a href="">{{ item.url }}</a>
+    </span>
+    <span v-if="!item.link">
+      {{ item.url }}
+    </span>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    item: { required: true, type: Object },
+  },
+}
+</script>

--- a/src/.vuepress/components/Network/ServiceTableRow.vue
+++ b/src/.vuepress/components/Network/ServiceTableRow.vue
@@ -1,0 +1,24 @@
+<template>
+  <tr v-if="services">
+    <td>
+      <strong>{{ title }}</strong>
+    </td>
+    <td>
+      <ul>
+        <li v-for="item in services">
+          <Network-ServiceItem :item="item" />
+        </li>
+      </ul>
+    </td>
+  </tr>
+</template>
+
+<script>
+export default {
+  props: {
+    services: { required: true },
+    title: { required: true, type: String }
+  },
+}
+</script>
+

--- a/src/.vuepress/components/Network/Services.vue
+++ b/src/.vuepress/components/Network/Services.vue
@@ -1,0 +1,40 @@
+<template>
+  <div>
+    <h4>Unification Foundation</h4>
+    <table>
+      <Network-ServiceTableRow :services="services?.seed?.foundation" title="Seeds" />
+      <Network-ServiceTableRow :services="services?.rpc?.foundation" title="RPCs" />
+      <Network-ServiceTableRow :services="services?.rest?.foundation" title="REST" />
+      <Network-ServiceTableRow :services="services?.explorer?.foundation" title="Explorer" />
+    </table>
+    <div v-if="parseInt(numCommunity, 10) > 0">
+      <h4>Community</h4>
+      <table>
+        <Network-ServiceTableRow v-if="services?.seed?.community.length > 0" :services="services?.seed?.community" title="Seeds" />
+        <Network-ServiceTableRow v-if="services?.rpc?.community.length > 0" :services="services?.rpc?.community" title="RPCs" />
+        <Network-ServiceTableRow v-if="services?.rest?.community.length > 0" :services="services?.rest?.community" title="REST" />
+        <Network-ServiceTableRow v-if="services?.explorer?.community.length > 0" :services="services?.explorer?.community" title="Explorer" />
+      </table>
+    </div>
+    <div v-if="parseInt(numLegacy, 10) > 0">
+      <h4>Legacy (pre {{ currentChainId }})</h4>
+      <table>
+        <Network-ServiceTableRow v-if="services?.seed?.legacy.length > 0" :services="services?.seed?.legacy" title="Seeds" />
+        <Network-ServiceTableRow v-if="services?.rpc?.legacy.length > 0" :services="services?.rpc?.legacy" title="RPCs" />
+        <Network-ServiceTableRow v-if="services?.rest?.legacy.length > 0" :services="services?.rest?.legacy" title="REST" />
+        <Network-ServiceTableRow v-if="services?.explorer?.legacy.length > 0" :services="services?.explorer?.legacy" title="Explorer" />
+      </table>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    services: { required: true, type: Object },
+    currentChainId: {required: true },
+    numCommunity: {required: true },
+    numLegacy: {required: true },
+  },
+}
+</script>

--- a/src/.vuepress/components/Network/Upgrades.vue
+++ b/src/.vuepress/components/Network/Upgrades.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <table>
+      <thead>
+      <th><code>und</code></th>
+      <th>Chain Id</th>
+      <th>From #</th>
+      <th>To #</th>
+      <th>State Export Required?*</th>
+      </thead>
+      <tbody>
+      <tr v-for="item in upgrades">
+        <td>{{ item.und }}</td>
+        <td>{{ item.chain_id }}</td>
+        <td>{{ item.from }}</td>
+        <td>{{ item.to }}</td>
+        <td>{{ item.state_export }}</td>
+      </tr>
+      </tbody>
+    </table>
+    <p><strong>*</strong>State export and migration to new genesis to upgrade from previous version</p>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    upgrades: { required: true, type: Array },
+  },
+}
+</script>

--- a/src/.vuepress/sidebars/mainchain.js
+++ b/src/.vuepress/sidebars/mainchain.js
@@ -26,15 +26,16 @@ module.exports = {
     {
       title: 'Networks',
       children: [
+        'networks/overview',
         {
-          title: 'Public Networks',
+          title: 'Join Public Networks',
           children: [
             'networks/join-network',
             'networks/become-validator'
           ]
         },
         {
-          title: 'DevNet',
+          title: 'Run a Local DevNet',
           children: [
             'networks/devnet/local-devnet-docker',
             'networks/devnet/single-node-devnet'

--- a/src/mainchain/README.md
+++ b/src/mainchain/README.md
@@ -39,6 +39,7 @@ to interact with the Mainchain network.
 
 ## 3. Mainchain Networks
 
+- [Network Overview](networks/overview.md)
 - [Join a Network](networks/join-network.md)
 - [Becoming a Validator](networks/become-validator.md)
 

--- a/src/mainchain/networks/overview.md
+++ b/src/mainchain/networks/overview.md
@@ -1,0 +1,9 @@
+# FUND Network Overview
+
+## MainNet
+
+<Network-Overview network="mainnet" />
+
+## TestNet
+
+<Network-Overview network="testnet" />


### PR DESCRIPTION
The network overview page pulls in data from the respective network Github repos (testnet/mainnet) and displays:

- upgrade info: relating to which `und` version is supported to which block number
- servies: a list of foundation, community and legacy services (RPC, REST etc.)

Data can be updated via the respective testnet/mainnet repos' `latest/network_info.json` file, and will be reflected in the overview page.