### PR TITLE
mainchain - add guide for full sync from legacy MainNet

### DIFF
--- a/src/.vuepress/sidebars/mainchain.js
+++ b/src/.vuepress/sidebars/mainchain.js
@@ -104,10 +104,16 @@ module.exports = {
       ]
     },
     {
-      title: 'Cloud Installation Guides',
+      title: 'Guides',
       children: [
-        'guides/cloud/install-aws',
-        'guides/cloud/install-gc'
+        'guides/legacy-to-current',
+        {
+          title: 'Cloud Installation',
+          children: [
+            'guides/cloud/install-aws',
+            'guides/cloud/install-gc'
+          ]
+        }
       ]
     },
     {

--- a/src/mainchain/README.md
+++ b/src/mainchain/README.md
@@ -61,6 +61,7 @@ to interact with the Mainchain network.
 
 - [AWS 101: Introduction to installing `und` on AWS EC2 instances](guides/cloud/install-aws.md)
 - [Google Cloud 101: Introduction to installing `und` on Google Cloud VMs](guides/cloud/install-gc.md)
+- [Fully sync MainNet from Legacy to Current](guides/legacy-to-current.md)
 
 ## 5. Developer guides
 


### PR DESCRIPTION
A new guide to fully sync a node form `FUND-Mainchain-MainNet-v1` genesis, using `und` v1.4.8, up to the latest block on `FUND-MainNet-2`